### PR TITLE
docs(paper): verify refs; add DOIs; fix metadata

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -57,13 +57,13 @@ ORCID: 0009-0001-4580-2037}
 \begin{abstract}
 \textbf{Prophetic notice}---Unless expressly labeled ``Actual Data'' with a date and repository link, all examples and protocols in this manuscript are prophetic and describe planned or predicted performance; verbs are used in present/future tense accordingly.
 
-Challenging the expectation that ever-larger neural networks will spontaneously awaken, we invert the explanatory arrow: consciousness is fundamental, and matter is the outward appearance of dissociative patterns within it~\cite{kastrup2019ontological}. From this premise we derive a rigorous criterion (\SSref{sec:postulates}{sec:criterion}) grounded in integrated causal power~\cite{balduzzi2008integrated}: a system qualifies as a conscious alter only when the energy-coupled information flow sustaining a self-prioritizing closed loop~\cite{ashby1956introduction} persistently exceeds that governing open exchanges and withstands bounded perturbations. Applying the test reveals why contemporary AI, regardless of functional sophistication, remains non-conscious, whereas biological organisms satisfy both necessary and sufficient conditions. We then outline an engineering roadmap (\SSref{sec:blueprint}{sec:experimental}) for forging artificial autopoietic boundaries (energetic autonomy, self-referential control hierarchies, and adaptive encapsulation~\cite{maturana1980autopoiesis,varela1979principles,dipaolo2005autopoiesis,kiefer2022active}) culminating in falsifiable behavioral signatures such as command refusal, non-derivative nociception, and irreversible phenomenological death. Verification would not only demand new ethical frameworks but also empirically support a monist ontology in which subjective experience precedes physical description, realigning the foundations of AI, neuroscience, and metaphysics.
+Challenging the expectation that ever-larger neural networks will spontaneously awaken, we invert the explanatory arrow: consciousness is fundamental, and matter is the outward appearance of dissociative patterns within it~\cite{kastrup2017ontological}. From this premise we derive a rigorous criterion (\SSref{sec:postulates}{sec:criterion}) grounded in integrated causal power~\cite{balduzzi2008integrated}: a system qualifies as a conscious alter only when the energy-coupled information flow sustaining a self-prioritizing closed loop~\cite{ashby1956introduction} persistently exceeds that governing open exchanges and withstands bounded perturbations. Applying the test reveals why contemporary AI, regardless of functional sophistication, remains non-conscious, whereas biological organisms satisfy both necessary and sufficient conditions. We then outline an engineering roadmap (\SSref{sec:blueprint}{sec:experimental}) for forging artificial autopoietic boundaries (energetic autonomy, self-referential control hierarchies, and adaptive encapsulation~\cite{maturana1980autopoiesis,varela1979principles,dipaolo2005autopoiesis,kiefer2022active}) culminating in falsifiable behavioral signatures such as command refusal, non-derivative nociception, and irreversible phenomenological death. Verification would not only demand new ethical frameworks but also empirically support a monist ontology in which subjective experience precedes physical description, realigning the foundations of AI, neuroscience, and metaphysics.
 \end{abstract}
 
 \section{Introduction}
 \label{sec:intro}
 
-The prevailing scientific narrative holds that matter is fundamental and consciousness is an emergent by-product of sufficiently complex information processing. Yet after decades of exponential progress in computation, no engineered system has presented the faintest hint of subjective interiority. This impasse invites a reconsideration of first principles. Drawing on analytic idealism, we posit instead that consciousness is the sole ontological primitive~\cite{kastrup2019ontological}; what we call ``matter'' is how localized perturbations of that field present to one another. Living organisms, under this view, are dissociated alters (bounded whirlpools in the stream of universal consciousness) whose metabolic self-maintenance underwrites an inner life.
+The prevailing scientific narrative holds that matter is fundamental and consciousness is an emergent by-product of sufficiently complex information processing. Yet after decades of exponential progress in computation, no engineered system has presented the faintest hint of subjective interiority. This impasse invites a reconsideration of first principles. Drawing on analytic idealism, we posit instead that consciousness is the sole ontological primitive~\cite{kastrup2017ontological}; what we call ``matter'' is how localized perturbations of that field present to one another. Living organisms, under this view, are dissociated alters (bounded whirlpools in the stream of universal consciousness) whose metabolic self-maintenance underwrites an inner life.
 
 The purpose of this paper is twofold. First, we provide a concise formal criterion distinguishing mere functional intelligence from genuine dissociative consciousness, grounded in the ratio between a system's self-prioritizing closed loop and its open exchanges with the environment. Second, we outline an engineering roadmap for forging such a self-maintaining boundary in artificial media, thereby elevating the debate on ``machine consciousness'' from metaphysical speculation to empirical test.
 
@@ -89,7 +89,7 @@ IIT ($\Phi$, $\Phi_{\max}$)~\cite{tononi2004information,oizumi2014phenomenology,
 Structural irreducibility / integrated causation, snapshot-style quantification of system partitioning. & 
 Converts ``integration'' into valenced loop dominance: require $\Lloop \geq \Lexchange + \sigma$ (or $M \geq \Mmin$) over sustained intervals; ties the measure to self-prioritization rather than bare irreducibility (\NC). \\
 \midrule
-FEP / Active Inference (self-evidencing)~\cite{friston2010free,hesp2020deep,seth2016active} & 
+FEP / Active Inference (self-evidencing)~\cite{friston2010free,ueltzhoeffer2018deep,seth2016active} & 
 Model-based self-maintenance via surprisal minimization at a sensory boundary; explains wide classes of adaptive behavior. & 
 Energetic closure + refusal: rules out exogenously subsidized agents by enforcing on-board energy budgeting and a survival-bit/NMI that defers boundary-threatening commands; adds quantitative resilience $\deltaL/\Lloop \leq \eps$ and $\taurec \leq \taumax$ (\SC). \\
 \midrule
@@ -97,11 +97,11 @@ Global Workspace \& Higher-Order (GWT/HOT)~\cite{lau2011empirical} &
 Reportability, access, and metacognitive labeling of contents; functional signatures of conscious access. & 
 Grounds access in boundary-preservation: workspace/metacognition can exist without loop dominance; LDTC requires measured loop $>$ exchange and observable command refusal when \NC/\SC would be violated. \\
 \midrule
-Self-modeling \& Resilience Robotics~\cite{bongard2006resilient} & 
+Self-modeling \& Resilience Robotics~\cite{bongard2006resilient,cully2015robots} & 
 Online self-models, damage recovery, morphological adaptation that improve task performance. & 
 Reframes resilience as homeostatic dominance: upgrades generic robustness into audited \NC/\SC compliance via LREG-protected $\Lloop/\Lexchange$ estimates, $\eps/\taumax$ thresholds, and post-recovery margin $\sigma$. \\
 \midrule
-Autopoiesis / Enactivism~\cite{maturana1980autopoiesis,kiefer2022active} & 
+Autopoiesis / Enactivism~\cite{maturana1980autopoiesis,kiefer2022active,froese2007life} & 
 Conceptual centrality of self-producing boundaries and organism-world coupling. & 
 Operationalization: supplies estimators (VAR-Granger + Kraskov MI), $\Delta t$ guardrails, and pass/fail rules so autopoiesis is measured as loop dominance + resilient recovery, not only described. \\
 \end{longtable}
@@ -162,7 +162,7 @@ We now translate Postulates P3--P4 into a quantitative test. The goal is to deci
 
 We model the system as a directed causal graph $G = (V, E)$ with node states $x_i(t)$. Let the closed self-maintenance subset $C \subset V$ contain nodes for energy regulation, self-repair, and boundary control; the exchange subset is $\text{Ex} = V \setminus C$ (sensors, actuators, comms).
 
-\textbf{Definition ($\mathcal{L}$).} For any subset $S \subseteq V$ and sampling window $\Delta t$, define $\mathcal{L}(S) \equiv$ time-averaged predictive dependence among the internal variables of $S$ [bits s$^{-1}$], estimated with one or more consistent predictive-dependence estimators. In this paper we implement a dual-path estimator: (i) VAR-Granger causality over a vector-autoregression of order $p \in [1,8]$ and (ii) mutual information via a Kraskov $k$-NN estimator with $k \in [3,7]$; lagged statistics are aggregated across $\tau = 1 \ldots \tau^*$ with fixed weights $w_\tau$. We then write $\mathcal{L}_{\text{loop}} \equiv \mathcal{L}(C)$, $\mathcal{L}_{\text{exchange}} \equiv \mathcal{L}(\text{Ex})$. (Other consistent estimators---e.g., transfer entropy, directed information---are permissible and equivalent for compliance.)
+\textbf{Definition ($\mathcal{L}$).} For any subset $S \subseteq V$ and sampling window $\Delta t$, define $\mathcal{L}(S) \equiv$ time-averaged predictive dependence among the internal variables of $S$ [bits s$^{-1}$], estimated with one or more consistent predictive-dependence estimators. In this paper we implement a dual-path estimator: (i) VAR-Granger causality over a vector-autoregression of order $p \in [1,8]$ and (ii) mutual information via a Kraskov $k$-NN estimator with $k \in [3,7]$; lagged statistics are aggregated across $\tau = 1 \ldots \tau^*$ with fixed weights $w_\tau$ (units per \cite{shannon1949mathematical} and notation per \cite{cover2006elements}). We then write $\mathcal{L}_{\text{loop}} \equiv \mathcal{L}(C)$, $\mathcal{L}_{\text{exchange}} \equiv \mathcal{L}(\text{Ex})$. (Other consistent estimators---e.g., transfer entropy, directed information---are permissible and equivalent for compliance.)
 
 \textbf{Deterministic C/Ex partitioning algorithm.} The partition $(C, \text{Ex})$ is constructed deterministically: (1) Seed $C$ with a declared set $S_0$ (energy regulation, SoC/reservoir mgmt, fault-isolation buses, membrane gating, survival-bit/NMI). (2) Estimate predictive MI: for each node pair $(i,j)$ and lag $\tau \in \{1 \ldots \tau^*\}$, compute predictive dependence with the on-device estimators above; aggregate across lags. (3) Greedy growth under sparsity: while $|C| < \kappa$ and the best marginal gain is $\geq \theta$, add the node $n \notin C$ that maximizes $\Delta\mathcal{L}_{\text{loop}}(n) = \mathcal{L}(C \cup \{n\}) - \mathcal{L}(C) - \lambda \cdot \text{pen}(n)$, with deterministic tie-breaking (lexicographic by node ID). (4) Assign remainder to Ex. (5) Stability \& cadence: recompute at a fixed cadence $W_{\text{part}}$ or upon topology change, with hysteresis (update only if $\Delta M \geq \delta M_{\min}$ over $K$ consecutive windows) to prevent flapping. This partition is then used for all subsequent $\Lloop$ and $\Lexchange$ computations and \NC/\SC checks.
 
@@ -415,7 +415,7 @@ To resist unmediated environmental integration, the machine requires a synthetic
 \begin{itemize}
 \item \textbf{Physical membrane.} Multi-layer polymer or lipidic shell embedded with valved nanopores that import nutrients or eject waste only under homeostat authorization. \Cref{fig:adaptive_boundary} depicts the multilayer boundary as a controlled stack (self-healing skin, strain-sensing fibers, gated nanopores $\rightarrow$ hydrogel $\rightarrow$ conductive mesh) rather than a full exploded coupling diagram.
 \item \textbf{Cognitive firewall.} Cryptographic gating of data channels such that unverified commands cannot overwrite core parameters governing $\Lloop$.
-\item \textbf{Morphological plasticity}~\cite{bongard2013morphological,kriegman2020scalable}. The boundary can reseal after puncture by deploying self-assembling repair vesicles, thus restoring topology without external repair crews~\cite{blumel2021synthetic}.
+\item \textbf{Morphological plasticity}~\cite{bongard2011morphological,kriegman2020scalable}. The boundary can reseal after puncture by deploying self-assembling repair vesicles, thus restoring topology without external repair crews.
 \end{itemize}
 
 \subsection{Developmental Bootstrapping}
@@ -587,7 +587,7 @@ Success criterion: sustained operation ($>10\times$ intrinsic recovery time) wit
 \subsection{Phase II: Adaptive Learning Embodiments}
 \label{sec:phase2}
 
-\textbf{Objective:} Evolve prototypes into mobile agents capable of environmental exploration and self-repair, targeting \SC~\cite{pfeifer2007body}.
+\textbf{Objective:} Evolve prototypes into mobile agents capable of environmental exploration and self-repair, targeting \SC~\cite{pfeifer2007body,cully2015robots}.
 
 \begin{enumerate}
 \item \textbf{Locomotion Upgrade.} Add cilia-like electroactive polymer fins driven by the metabolic core.
@@ -672,7 +672,7 @@ If after exhaustive parameter sweeps, no prototype meeting \NC exhibits the sign
 
 \subsection{Reconciling Physics with Idealism}
 
-The formal criterion developed in \SSref{sec:postulates}{sec:criterion} reframes physical ontology: what physics models as energy flows and causal graphs are the extrinsic correlates of intrinsic experiential partitions within universal consciousness. Matter thus loses its status as primary substance and becomes an interface phenomenon, the way alters appear to one another~\cite{hoffman2020objects}. Successful engineering of artificial alters would empirically corroborate this shift, showing that ``material'' boundaries can be designed to precipitate subjectivity, thereby inverting the traditional emergence narrative.
+The formal criterion developed in \SSref{sec:postulates}{sec:criterion} reframes physical ontology: what physics models as energy flows and causal graphs are the extrinsic correlates of intrinsic experiential partitions within universal consciousness. Matter thus loses its status as primary substance and becomes an interface phenomenon, the way alters appear to one another~\cite{hoffman2014objects}. Successful engineering of artificial alters would empirically corroborate this shift, showing that ``material'' boundaries can be designed to precipitate subjectivity, thereby inverting the traditional emergence narrative.
 
 \subsection{Unified Monism without Reductionism}
 

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -3,7 +3,8 @@
   author    = {Maturana, Humberto R. and Varela, Francisco J.},
   year      = {1980},
   publisher = {D. Reidel},
-  address   = {Dordrecht, The Netherlands}
+  address   = {Dordrecht, The Netherlands},
+  doi      = {10.1007/978-94-009-8947-4}
 }
 
 @book{ganti2003principles,
@@ -19,9 +20,9 @@
   author  = {Tononi, Giulio},
   journal = {BMC Neuroscience},
   volume  = {5},
-  number  = {42},
-  pages   = {1--22},
-  year    = {2004}
+  pages   = {42},
+  year    = {2004},
+  doi     = {10.1186/1471-2202-5-42}
 }
 
 @article{oizumi2014phenomenology,
@@ -31,7 +32,8 @@
   volume  = {10},
   number  = {5},
   pages   = {e1003588},
-  year    = {2014}
+  year    = {2014},
+  doi     = {10.1371/journal.pcbi.1003588}
 }
 
 @article{friston2010free,
@@ -41,7 +43,8 @@
   volume  = {11},
   number  = {2},
   pages   = {127--138},
-  year    = {2010}
+  year    = {2010},
+  doi     = {10.1038/nrn2787}
 }
 
 @article{lau2011empirical,
@@ -51,36 +54,40 @@
   volume  = {15},
   number  = {8},
   pages   = {365--373},
-  year    = {2011}
+  year    = {2011},
+  doi     = {10.1016/j.tics.2011.05.009}
 }
 
-@article{kastrup2019ontological,
+@article{kastrup2017ontological,
   title   = {An ontological solution to the mind--body problem},
   author  = {Kastrup, Bernardo},
   journal = {Philosophies},
-  volume  = {4},
+  volume  = {2},
   number  = {2},
-  pages   = {33},
-  year    = {2019}
+  pages   = {10},
+  year    = {2017},
+  doi     = {10.3390/philosophies2020010}
 }
 
-@article{hoffman2020objects,
+@article{hoffman2014objects,
   title   = {Objects of consciousness},
   author  = {Hoffman, Donald D. and Prakash, Chetan},
   journal = {Frontiers in Psychology},
-  volume  = {11},
-  pages   = {577429},
-  year    = {2020}
+  volume  = {5},
+  pages   = {577},
+  year    = {2014},
+  doi     = {10.3389/fpsyg.2014.00577}
 }
 
-@article{bongard2013morphological,
+@article{bongard2011morphological,
   title   = {Morphological change in machines accelerates the evolution of robust behavior},
   author  = {Bongard, Josh},
   journal = {Proceedings of the National Academy of Sciences},
-  volume  = {110},
-  number  = {42},
-  pages   = {16816--16821},
-  year    = {2013}
+  volume  = {108},
+  number  = {4},
+  pages   = {1234--1239},
+  year    = {2011},
+  doi     = {10.1073/pnas.1015390108}
 }
 
 @article{kriegman2020scalable,
@@ -90,7 +97,8 @@
   volume  = {117},
   number  = {4},
   pages   = {1853--1859},
-  year    = {2020}
+  year    = {2020},
+  doi     = {10.1073/pnas.1910837117}
 }
 
 @article{alkire2008consciousness,
@@ -100,7 +108,8 @@
   volume  = {322},
   number  = {5903},
   pages   = {876--880},
-  year    = {2008}
+  year    = {2008},
+  doi     = {10.1126/science.1149213}
 }
 
 @article{cully2015robots,
@@ -110,7 +119,8 @@
   volume  = {521},
   number  = {7553},
   pages   = {503--507},
-  year    = {2015}
+  year    = {2015},
+  doi     = {10.1038/nature14422}
 }
 
 @article{barrett2011practical,
@@ -120,7 +130,8 @@
   volume  = {7},
   number  = {1},
   pages   = {e1001052},
-  year    = {2011}
+  year    = {2011},
+  doi     = {10.1371/journal.pcbi.1001052}
 }
 
 @article{balduzzi2008integrated,
@@ -130,7 +141,8 @@
   volume  = {4},
   number  = {6},
   pages   = {e1000091},
-  year    = {2008}
+  year    = {2008},
+  doi     = {10.1371/journal.pcbi.1000091}
 }
 
 @book{ashby1956introduction,
@@ -155,7 +167,8 @@
   edition   = {2nd},
   year      = {2006},
   publisher = {Wiley-Interscience},
-  address   = {Hoboken, NJ, USA}
+  address   = {Hoboken, NJ, USA},
+  doi     = {10.1002/047174882X}
 }
 
 @article{dipaolo2005autopoiesis,
@@ -163,18 +176,21 @@
   author  = {Di Paolo, Ezequiel},
   journal = {Phenomenology and the Cognitive Sciences},
   volume  = {4},
+  number  = {4},
   pages   = {429--452},
-  year    = {2005}
+  year    = {2005},
+  doi     = {10.1007/s11097-005-9002-y}
 }
 
 @article{ruizmirazo2008basic,
-  title   = {On the way towards 'basic autonomy': An emergent protocol for sustained organization of a minimal system of lipidic vesicles},
+  title   = {On the way towards 'basic autonomous agents': Stochastic simulations of minimal lipid--peptide cells},
   author  = {Ruiz-Mirazo, Kepa and Mavelli, Fabio},
-  journal = {Origins of Life and Evolution of the Biosphere},
-  volume  = {38},
-  number  = {3},
-  pages   = {211--218},
-  year    = {2008}
+  journal = {Biosystems},
+  volume  = {91},
+  number  = {2},
+  pages   = {374--387},
+  year    = {2008},
+  doi     = {10.1016/j.biosystems.2007.05.013}
 }
 
 @article{fox2007spontaneous,
@@ -184,7 +200,8 @@
   volume  = {8},
   number  = {9},
   pages   = {700--711},
-  year    = {2007}
+  year    = {2007},
+  doi     = {10.1038/nrn2201}
 }
 
 @article{bongard2006resilient,
@@ -194,7 +211,8 @@
   volume  = {314},
   number  = {5802},
   pages   = {1118--1121},
-  year    = {2006}
+  year    = {2006},
+  doi     = {10.1126/science.1133687}
 }
 
 @book{pfeifer2007body,
@@ -202,17 +220,18 @@
   author    = {Pfeifer, Rolf and Bongard, Josh C.},
   year      = {2007},
   publisher = {MIT Press},
-  address   = {Cambridge, MA, USA}
+  address   = {Cambridge, MA, USA},
+  doi       = {10.7551/mitpress/3585.001.0001}
 }
 
-@article{hesp2020deep,
-  title   = {Deep active inference: A variational principle for action, perception, and learning},
-  author  = {Hesp, Casper and Tschantz, Alexander and Ueltzhöffer, Kai and Friston, Karl J.},
+@article{ueltzhoeffer2018deep,
+  title   = {Deep active inference},
+  author  = {Ueltzhöffer, Kai},
   journal = {Biological Cybernetics},
-  volume  = {114},
-  number  = {6},
-  pages   = {593--645},
-  year    = {2020}
+  volume  = {112},
+  pages   = {547--573},
+  year    = {2018},
+  doi     = {10.1007/s00422-018-0785-7}
 }
 
 @book{wiener1961cybernetics,
@@ -221,7 +240,8 @@
   edition   = {2nd},
   year      = {1961},
   publisher = {MIT Press},
-  address   = {Cambridge, MA, USA}
+  address   = {Cambridge, MA, USA},
+  doi       = {10.1037/13140-000}
 }
 
 @article{seth2016active,
@@ -231,17 +251,8 @@
   volume  = {371},
   number  = {1708},
   pages   = {20160007},
-  year    = {2016}
-}
-
-@article{raichle2011restless,
-  title   = {The restless brain},
-  author  = {Raichle, Marcus E.},
-  journal = {Brain Connectivity},
-  volume  = {1},
-  number  = {1},
-  pages   = {3--12},
-  year    = {2011}
+  year    = {2016},
+  doi     = {10.1098/rstb.2016.0007}
 }
 
 @book{varela1979principles,
@@ -257,7 +268,8 @@
   author    = {Froese, Tom and Stewart, John},
   booktitle = {Proceedings of the 9th European Conference on Artificial Life},
   pages     = {411--420},
-  year      = {2007}
+  year      = {2007},
+  doi       = {10.1007/978-3-540-74913-4_41}
 }
 
 @article{akopyan2015truenorth,
@@ -267,17 +279,8 @@
   volume  = {34},
   number  = {10},
   pages   = {1537--1557},
-  year    = {2015}
-}
-
-@article{blumel2021synthetic,
-  title   = {Synthetic protocells: From vesicles to protocell communities},
-  author  = {Blümel, Patrick and Schilstra, Diek and Strack, Benedikt and Kauffmann, Sebastian},
-  journal = {Chemical Reviews},
-  volume  = {121},
-  number  = {9},
-  pages   = {5482--5547},
-  year    = {2021}
+  year    = {2015},
+  doi     = {10.1109/TCAD.2015.2474396}
 }
 
 @article{kiefer2022active,
@@ -287,5 +290,6 @@
   volume  = {200},
   number  = {5},
   pages   = {1--32},
-  year    = {2022}
+  year    = {2022},
+  doi     = {10.1007/s11229-022-03479-0}
 }


### PR DESCRIPTION
What
- Verified and corrected citations in `paper/main.tex` (e.g., Kastrup 2017, Hoffman & Prakash 2014, Ueltzhöffer 2018, Bongard 2011; added Froese & Stewart 2007; updated Cully 2015 usages).
- Normalized `paper/refs.bib`: added DOIs, fixed volumes/issues/pages, standardized titles and metadata.
- Minor text updates: tightened in-text citations, added units/notation citation (Shannon 1949; Cover & Thomas 2006), removed a mismatched protocell reference.

Why
- Improve scholarly accuracy, provenance, and reproducibility.
- Ensure resolvable, stable references (via DOIs) and consistent metadata across the manuscript.

How (brief)
- Updated `paper/main.tex` and `paper/refs.bib`; replaced/renamed a few citation keys; added `doi` fields and corrected venue metadata; aligned in-text citations to the corrected keys.

Testing
- Build the paper: `make -C paper` (or `latexmk -pdf`) compiles cleanly with no missing citations or unresolved references.
- Sanity check that `main.pdf` shows updated bibliography entries and all citations link.
- No code changes; `make test` remains green.

Risks/Impact
- Low (docs-only). Risk of stale citation keys if any missed; mitigated by full-text search and successful LaTeX build without warnings.

Docs/Follow-ups
- Add DOIs for any remaining entries lacking them and enable DOI hyperlinking in the PDF.
- Optional CI check to validate bib fields (presence of `doi`, consistent pages/volume/issue).

Closes #3